### PR TITLE
Fix parser and generator for pi.cfg

### DIFF
--- a/test/testdata/pi.cfg
+++ b/test/testdata/pi.cfg
@@ -1,11 +1,15 @@
 import logging
 PI_PEPPER = 'zzsWra6vnoYFrlVXJM3DlgPO'
 SQLALCHEMY_DATABASE_URI = 'mysql://pi:P4yvb3d1Thw_@localhost/pi'
-PI_LOGCONFIG = '"/etc/privacyidea/logging.cfg"'
+PI_LOGCONFIG = '/etc/privacyidea/logging.cfg'
 PI_AUDIT_KEY_PUBLIC = './test/testdata/public.pem'
 PI_ENCFILE = './test/testdata/enckey'
 PI_LOGLEVEL = logging.DEBUG
-PI_LOGFILE = '"/var/log/privacyidea/privacyidea.log"'
+PI_LOGFILE = '/var/log/privacyidea/privacyidea.log'
 PI_AUDIT_KEY_PRIVATE = './test/testdata/private.pem'
 SECRET_KEY = 'sfYF0kW6MsZmmg9dBlf5XMWE'
 SUPERUSER_REALM = ['super', 'heros']
+PI_AUDIT_POOL_SIZE = 20
+
+# test
+PI_AUDIT_SQL_TRUNCATE = True


### PR DESCRIPTION
Fix parser and generator for pi.cfg
    
This fixes the parsing of SQLALCHEMY_DATABASE_URI, the accidental
double-quoting of strings and conversion of Booleans and integers to
strings.
    
Closes #58
Closes #60
