### PR TITLE
Import the privacyidea package from the distribution package

### DIFF
--- a/authappliance/menu.py
+++ b/authappliance/menu.py
@@ -21,13 +21,15 @@ from __future__ import print_function
 import locale
 import argparse
 import sys
+import platform
 import os
 from traceback import print_exc
 
 # If the ``privacyidea`` Python package cannot be imported normally,
 # append the virtualenv site-packages of the privacyIDEA 3.x distribution
 # packages to the search path and try again.
-PRIVACYIDEA_SITE_PACKAGES = '/opt/privacyidea/lib/python2.7/site-packages/'
+site_version = 'python' + '.'.join(platform.python_version_tuple()[0:2])
+PRIVACYIDEA_SITE_PACKAGES = '/opt/privacyidea/lib/' + site_version + '/site-packages/'
 try:
     import privacyidea
 except ImportError:

--- a/authappliance/menu.py
+++ b/authappliance/menu.py
@@ -17,10 +17,30 @@
 """
 text dialog based setup tool to configure the privacyIDEA basics.
 """
-
+from __future__ import print_function
 import locale
 import argparse
 import sys
+import os
+from traceback import print_exc
+
+# If the ``privacyidea`` Python package cannot be imported normally,
+# append the virtualenv site-packages of the privacyIDEA 3.x distribution
+# packages to the search path and try again.
+PRIVACYIDEA_SITE_PACKAGES = '/opt/privacyidea/lib/python2.7/site-packages/'
+try:
+    import privacyidea
+except ImportError:
+    if os.path.isdir(PRIVACYIDEA_SITE_PACKAGES):
+        sys.path.append(PRIVACYIDEA_SITE_PACKAGES)
+    try:
+        import privacyidea
+    except ImportError:
+        print('The privacyidea module cannot be found in the search path: {!r}'.format(sys.path), file=sys.stderr)
+        print_exc(file=sys.stderr)
+        print('Exiting.', file=sys.stderr)
+        sys.exit(1)
+
 import time
 from functools import partial
 


### PR DESCRIPTION
The appliance now performs the following steps:
* We try to normally import ``privacyidea``, e.g. from the current virtualenv
* If this fails, we check if ``/opt/privacyidea/lib/python2.7/site-packages`` exists. If yes, we add it to the search path for Python modules and try to import ``privacyidea`` again.
* If this fails again, we exit with an error.
 
Working on #56