### PR TITLE
Streamline setup.py, requirements.txt and test/requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ paramiko==2.4.2
 pyasn1==0.4.5
 pycparser==2.19
 PyNaCl==1.3.0
-pyparsing==2.4.0
+pyparsing==2.0.3
 pythondialog==3.0.1; python_version >= '3.0'
 python2-pythondialog==3.4.0; python_version < '3.0'
 six==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,13 @@ cffi==1.12.3
 configobj==5.0.6
 cryptography==2.6.1
 enum34==1.1.6; python_version < '3.0'
-funcsigs==1.0.2
 ipaddress==1.0.22; python_version < '3.0'
 netaddr==0.7.19
 paramiko==2.4.2
-pbr==5.2.0
 pyasn1==0.4.5
 pycparser==2.19
 PyNaCl==1.3.0
-pyparsing==2.0.3
+pyparsing==2.4.0
 pythondialog==3.0.1; python_version >= '3.0'
 python2-pythondialog==3.4.0; python_version < '3.0'
-six==1.10.0
+six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
                       'netaddr',
                       'paramiko>=2.4.2',
                       'pyparsing',
-                      'six'
+                      'six',
+                      'configobj'
                       ],
     scripts=['authappliance/pi-appliance',
              'tools/pi-appliance-update'],

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,13 @@
 -r ../requirements.txt
-coverage==4.5.3
-mock==2.0.0
-pytest==3.6.4
+atomicwrites==1.3.0
+attrs==19.1.0
+funcsigs==1.0.2
+mock==3.0.5
+more-itertools==5.0.0; python_version < '3.0'
+more-itertools==7.0.0; python_version >= '3.0'
+pathlib2==2.3.3; python_version < '3.0'
+pluggy==0.11.0
+py==1.8.0
+pytest==4.5.0
+scandir==1.10.0; python_version < '3.0'
+wcwidth==0.1.7


### PR DESCRIPTION
This PR ...
* adds configobj to ``setup.py``, which we missed until now :)
* removes some obsolete dependencies from ``requirements.txt``
* bumps six to the latest version
* but keeps pyparsing at 2.0.3, because 2.4.0 seems to introduce some API changes. As we do not have a lot of tests, I think it's safer to not upgrade pyparsing just now
* and adds some packages to ``test/requirements.txt``, as suggested by @plettich :)