### PR TITLE
Fix broken lines in dialog

### DIFF
--- a/authappliance/menu.py
+++ b/authappliance/menu.py
@@ -2109,6 +2109,7 @@ def create_arguments():
 
 def main():
     locale.setlocale(locale.LC_ALL, '')
+    os.environ['NCURSES_NO_UTF8_ACS'] = '1'
     args = create_arguments()
     pS = MainMenu(config=args.file)
     pS.main_menu()


### PR DESCRIPTION
Setting NCURSES_NO_UTF8_ACS=1 in the environment, fixes the broken border
issue i.e. when used with putty.
See https://invisible-island.net/ncurses/ncurses.faq.html#utf8_line_drawing

Fixes #81