### PR TITLE
Fix Popen calls for Python 3

### DIFF
--- a/authappliance/lib/appliance.py
+++ b/authappliance/lib/appliance.py
@@ -484,42 +484,40 @@ class OSConfig(object):
         Reboot OS
         """
         p = Popen(["sudo", 'reboot'])
-        _output, _err = p.communicate()
-        r = p.returncode
+        r = p.wait()
         if r == 0:
             if echo:
                 print("Rebooting system.")
         else:
             if echo:
-                print(_err)
+                print("Unable to reboot system!")
 
     def halt(self, echo=False):
         """
         Shutdown OS
         """
         p = Popen(["sudo", 'halt'])
-        _output, _err = p.communicate()
-        r = p.returncode
+        r = p.wait()
         if r == 0:
             if echo:
                 print("Halting system.")
         else:
             if echo:
-                print(_err)
+                print("Unable to halt system!")
 
     def set_password(self, username):
         call(["passwd", username])
 
     def change_password(self, username, password, echo=False):
-        p = Popen(['chpasswd'], stdin=PIPE, universal_newlines=True)
-        _output, _err = p.communicate(u"%s:%s" % (username, password))
+        p = Popen(['chpasswd'], stdin=PIPE, stderr=PIPE, universal_newlines=True)
+        _output, err = p.communicate(u"%s:%s" % (username, password))
         r = p.returncode
         if r == 0:
             if echo:
                 print("Password changed.")
         else:
             if echo:
-                print(_err)
+                print(err)
 
     def get_diskfree(self):
         # TODO: get the disk size
@@ -528,15 +526,13 @@ class OSConfig(object):
     @classmethod
     def ifdown(cls, iface):
         p = Popen(['sudo', 'ifdown', iface])
-        _output, _err = p.communicate()
-        r = p.returncode
+        r = p.wait()
         print(r)
 
     @classmethod
     def ifup(cls, iface):
         p = Popen(['sudo', 'ifup', iface])
-        _output, _err = p.communicate()
-        r = p.returncode
+        r = p.wait()
         print(r)
 
     @classmethod
@@ -555,15 +551,16 @@ class OSConfig(object):
             commandline = ['sudo', 'service', service, action]
         else:
             commandline = ['sudo', 'systemctl', action, service]
-        p = Popen(commandline)
-        _output, _err = p.communicate()
-        r = p.returncode
-        if r == 0:
+        p = Popen(commandline, stderr=PIPE, universal_newlines=True)
+        _out, err = p.communicate()
+        if p.returncode == 0:
             if do_print:
                 print("Service %s %s" % (service, action))
         else:
             if do_print:
-                print(_err)
+                print("Unable to {0!s} service {1!s}: {2!s}".format(action,
+                                                                    service,
+                                                                    err))
 
 
 class ApacheConfig(object):

--- a/authappliance/lib/appliance.py
+++ b/authappliance/lib/appliance.py
@@ -483,27 +483,27 @@ class OSConfig(object):
         """
         Reboot OS
         """
-        p = Popen(["sudo", 'reboot'])
-        r = p.wait()
-        if r == 0:
+        p = Popen(["sudo", 'reboot'], stderr=PIPE, universal_newlines=True)
+        _out, err = p.communicate()
+        if p.returncode == 0:
             if echo:
                 print("Rebooting system.")
         else:
             if echo:
-                print("Unable to reboot system!")
+                print("Unable to reboot system: {0!s}".format(err))
 
     def halt(self, echo=False):
         """
         Shutdown OS
         """
-        p = Popen(["sudo", 'halt'])
-        r = p.wait()
-        if r == 0:
+        p = Popen(["sudo", 'halt'], stderr=PIPE, universal_newlines=True)
+        _out, err = p.communicate()
+        if p.returncode == 0:
             if echo:
                 print("Halting system.")
         else:
             if echo:
-                print("Unable to halt system!")
+                print("Unable to halt system: {0!s}".format(err))
 
     def set_password(self, username):
         call(["passwd", username])

--- a/authappliance/lib/ldap_proxy.py
+++ b/authappliance/lib/ldap_proxy.py
@@ -301,9 +301,7 @@ class LDAPProxyService(object):
 
     @staticmethod
     def _invoke_systemctl(arguments):
-        proc = subprocess.Popen(['systemctl'] + arguments,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(['systemctl'] + arguments)
         return proc.wait() == 0
 
     @staticmethod
@@ -312,13 +310,11 @@ class LDAPProxyService(object):
         Invoke ``systemctl show`` to retrieve the value of the given property
         of the LDAP proxy unit file. Return it as a string.
         """
-        try:
-            proc = subprocess.Popen(['systemctl', 'show', LDAP_PROXY_UNIT_FILE, '-p', property_name],
-                                    stdout=subprocess.PIPE, encoding='utf8')
-        except TypeError:
-            proc = subprocess.Popen(['systemctl', 'show', LDAP_PROXY_UNIT_FILE, '-p', property_name],
-                                    stdout=subprocess.PIPE)
-        output = proc.communicate()[0].strip()
+        proc = subprocess.Popen(['systemctl', 'show', LDAP_PROXY_UNIT_FILE,
+                                 '-p', property_name], stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, universal_newlines=True)
+        out, err = proc.communicate()
+        output = out.strip()
         return output.split("=", 1)[1]
 
     def restart(self):

--- a/authappliance/lib/utils.py
+++ b/authappliance/lib/utils.py
@@ -42,17 +42,18 @@ def execute_ssh_command_and_wait(ssh, command, timeout=1.):
         to_read, _, _ = select.select([channel], [], [], timeout)
         if to_read:
             if channel.recv_ready():
-                stdout_data.append(channel.recv(len(channel.in_buffer)))
+                stdout_data.append(channel.recv(len(channel.in_buffer)).decode())
             if channel.recv_stderr_ready():
-                stderr_data.append(channel.recv(len(channel.in_buffer)))
-        if channel.exit_status_ready() and not channel.recv_ready() and not channel.recv_stderr_ready():
+                stderr_data.append(channel.recv(len(channel.in_buffer)).decode())
+        if channel.exit_status_ready() and not channel.recv_ready() \
+                and not channel.recv_stderr_ready():
             channel.shutdown_read()
             channel.close()
             break
     stdout_file.close()
     stderr_file.close()
     exit_status = stdout_file.channel.recv_exit_status()
-    return exit_status, ''.join(stdout_data), ''.join(stderr_data)
+    return exit_status, u''.join(stdout_data), u''.join(stderr_data)
 
 
 def to_unicode(s, encoding="utf-8"):

--- a/test/test_privacyideaconfig.py
+++ b/test/test_privacyideaconfig.py
@@ -27,7 +27,7 @@ class TestPIConfig(unittest.TestCase):
         self.assertEqual(pic.config.get("SECRET_KEY"),
                          "sfYF0kW6MsZmmg9dBlf5XMWE")
         self.assertEqual(pic.config.get("SQLALCHEMY_DATABASE_URI"),
-                         'mysql://pi:P4yvb3d1Thw_@localhost/pi')
+                         'mysql+pymysql://pi:P4yvb3d1Thw_@localhost/pi')
 
         # save the config
         pic.save()
@@ -40,7 +40,7 @@ class TestPIConfig(unittest.TestCase):
         self.assertEqual(pic.config.get("SECRET_KEY"),
                          "sfYF0kW6MsZmmg9dBlf5XMWE")
         self.assertEqual(pic.config.get("SQLALCHEMY_DATABASE_URI"),
-                         'mysql://pi:P4yvb3d1Thw_@localhost/pi')
+                         'mysql+pymysql://pi:P4yvb3d1Thw_@localhost/pi')
         self.assertEqual(pic.config.get("PI_LOGLEVEL"), "logging.DEBUG")
         self.assertEqual(pic.config.get("SUPERUSER_REALM"), ['super'])
 


### PR DESCRIPTION
When using stdin, stdout or sterr of a Popen call, they usually expect/emit
binary data. In order to to work correctly with text in-/output, the
parameter `universal_newlines=True` is added.